### PR TITLE
fix iterable

### DIFF
--- a/github.py
+++ b/github.py
@@ -62,7 +62,7 @@ except:
     from io import StringIO
 
 import re, os, time, hmac, base64, hashlib, urllib, mimetypes, json
-from collections import Iterable
+from collections.abc import Iterable
 from datetime import datetime, timedelta, tzinfo
 
 TIMEOUT=60


### PR DESCRIPTION
Since version 3.10, the`collections`module itself does not contain`iterable`. To import it, you must try to join the `.abc`submodule.